### PR TITLE
Switch CI to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          profile: minimal
-          override: true
           target: ${{ matrix.target }}
 
       - name: Build target


### PR DESCRIPTION
Current actions-rs/toolchain is not actively maintained.

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>